### PR TITLE
 [JavaFileChecker] create search result where fullMatch is false  in findMethodInvocations

### DIFF
--- a/blade.migrate.liferay70/projects/filetests/JavaFileCheckerTest.java
+++ b/blade.migrate.liferay70/projects/filetests/JavaFileCheckerTest.java
@@ -1,6 +1,6 @@
 package blade.migrate.liferay70;
 
-public class Test {
+public class JavaFileChecker {
 	boolean value = false;
 
 	public static void main(String[] args) {
@@ -15,6 +15,17 @@ public class Test {
 				valueOf(1));
 
 		foo.bar("1");
+		JavaFileChecker andyTest = new Test();
+		String str = null;
+		andyTest.call(str , str , str);
+		andyTest.call(str , new String() , str);
+		andyTest.call(str , new String() , andyTest.getString());
+		andyTest.call(str , new String() , strange.getString());
+		andyTest.call2(str,str,str);
+		JavaFileChecker.staticCall(str, str, str);
+		JavaFileChecker.staticCall(str , new String() , str);
+		JavaFileChecker.staticCall(str , new String() , andyTest.getString());
+		JavaFileChecker.staticCall(str , new String() , strange.getString());
 	}
 
 	Foo foo = new Foo();
@@ -26,5 +37,14 @@ public class Test {
 	public void typeTest() {
 		NotFoo foo = new NotFoo();
 		foo.bar(false);
+	}
+
+	public String getString(){
+		return new String();
+	}
+
+
+	public static void staticCall(String str1 , String str2 , String str3){
+
 	}
 }

--- a/blade.migrate.liferay70/projects/filetests/JavaFileCheckerTestFile.java
+++ b/blade.migrate.liferay70/projects/filetests/JavaFileCheckerTestFile.java
@@ -22,7 +22,7 @@ public class JavaFileChecker {
 		andyTest.call(str , new String() , andyTest.getString());
 		andyTest.call(str , new String() , strange.getString());
 		andyTest.call2(str,str,str);
-		JavaFileChecker.staticCall(str, str, str);
+		JavaFileChecker.staticCall(str+"ss", str, str);
 		JavaFileChecker.staticCall(str , new String() , str);
 		JavaFileChecker.staticCall(str , new String() , andyTest.getString());
 		JavaFileChecker.staticCall(str , new String() , strange.getString());

--- a/blade.migrate.liferay70/src/blade/migrate/core/JavaFileChecker.java
+++ b/blade.migrate.liferay70/src/blade/migrate/core/JavaFileChecker.java
@@ -299,60 +299,41 @@ public class JavaFileChecker {
 
 					if (methodParamTypes != null) {
 						List<Expression>  argExpressions = (List<Expression>)node.arguments(); 
-						for(Expression express : argExpressions){
-							ITypeBinding myType = express.resolveTypeBinding();
-							if(myType != null){
-								System.out.println(myType.getName());
-							}else{
-								System.out.println("typebinding can be resolved");
-							}
-						}
-						Object[] args = node.arguments().toArray();
-
-						if (args != null && args.length == methodParamTypes.length) {
+						Expression[] args = new Expression[argExpressions.size()];
+						argExpressions.toArray(args);
+						if (argExpressions != null && args.length == methodParamTypes.length) {
 							//args number matched
 							boolean possibleMatch = true;
 
 							for(int i = 0; i < args.length; i++) {
-								Object arg = args[i];
-								ITypeBinding argType = null;
-								//class cast according to instance type , find three types by now
-								if (arg instanceof SimpleName) {
-									SimpleName simpleName = (SimpleName)arg;
-									argType = simpleName.resolveTypeBinding();
-								}
-								else if(arg instanceof ClassInstanceCreation){
-									ClassInstanceCreation classInstanceCreation = (ClassInstanceCreation)arg;
-									argType = classInstanceCreation.resolveTypeBinding();
-								}else if(arg instanceof MethodInvocation ){
-									MethodInvocation methodInvocation = (MethodInvocation)arg;
-									argType = methodInvocation.resolveTypeBinding();
-								}else if(arg instanceof BooleanLiteral){
-									BooleanLiteral booleanLiteral = (BooleanLiteral)arg;
-									argType = booleanLiteral.resolveTypeBinding();
-								}
-								else{
+								Expression arg = args[i];
+								ITypeBinding argType = arg.resolveTypeBinding();
+								if (argType != null ){
+									//can resolve the type
+									 if( argType.getName().equals(methodParamTypes[i])) {
+										 //type matched
+											continue;
+									 }else{
+										 //type unmatched
+										 possibleMatch = false;
+										 break;
+									 }
+								}else{
 									//TODO
-									//unknow arg type
-									System.out.println("error: unknow arg type");
+									//can't resolve the type but  args number matched . make a warning ?
 									possibleMatch = false;
-									break;
-								}
-								if (argType != null && argType.getName().equals(methodParamTypes[i])) {
-									continue;
-								}
-								else {
-									possibleMatch = false;
+									System.out.println("Guess Right : arg number is right but type is not fully matched . Line :"+_ast.getLineNumber(expression.getStartPosition()) +" File:"+_file.getName());
+									/*final int startOffset = expression.getStartPosition();
+									final int startLine = _ast.getLineNumber(startOffset);
+									final int endOffset = node.getStartPosition() + node.getLength();
+									final int endLine = _ast.getLineNumber(endOffset);
+									searchResults.add(new SearchResult(_file, startOffset,
+										endOffset, startLine, endLine));*/
 									break;
 								}
 							}
 							if (possibleMatch) {
 								match = true;
-							}
-							else{
-								//TODO
-								//args number matched but args types didn't match . make a warning ?
-								System.out.println("guess right! "+_ast.getLineNumber(expression.getStartPosition()));
 							}
 						}
 						//args number mismatched

--- a/blade.migrate.liferay70/test/blade/migrate/core/JavaFileCheckerTest.java
+++ b/blade.migrate.liferay70/test/blade/migrate/core/JavaFileCheckerTest.java
@@ -23,8 +23,8 @@ public class JavaFileCheckerTest {
 		assertNotNull(searchResult);
 		assertEquals( 14, searchResult.startLine );
 		assertEquals( 15, searchResult.endLine );
-		assertEquals( 218, searchResult.startOffset );
-		assertEquals( 240, searchResult.endOffset );
+		assertEquals( 229, searchResult.startOffset );
+		assertEquals( 251, searchResult.endOffset );
 	}
 
 	@Test
@@ -42,7 +42,18 @@ public class JavaFileCheckerTest {
 		assertNotNull(searchResult);
 		assertEquals( 10, searchResult.startLine );
 		assertEquals( 11, searchResult.endLine );
-		assertEquals( 170, searchResult.startOffset );
-		assertEquals( 189, searchResult.endOffset );
+		assertEquals( 181, searchResult.startOffset );
+		assertEquals( 200, searchResult.endOffset );
+	}
+	@Test
+	public void checkGuessMethodInvocation() {
+		File file = new File( "projects/filetests/JavaFileCheckerTest.java" );
+		JavaFileChecker javaFileChecker = new JavaFileChecker(file);
+		List<SearchResult> results = javaFileChecker.findMethodInvocations(null, "JavaFileChecker" , "staticCall", new String[]{"String","String","String"});
+		assertNotNull(results);
+		assertEquals(3, results.size());
+		results = javaFileChecker.findMethodInvocations("JavaFileChecker", null, "call", new String[]{"String","String","String"});
+		assertNotNull(results);
+		assertEquals(3, results.size());
 	}
 }

--- a/blade.migrate.liferay70/test/blade/migrate/core/JavaFileCheckerTest.java
+++ b/blade.migrate.liferay70/test/blade/migrate/core/JavaFileCheckerTest.java
@@ -12,7 +12,7 @@ public class JavaFileCheckerTest {
 
 	@Test
 	public void checkStaticMethodInvocation() throws Exception {
-		File file = new File( "projects/filetests/JavaFileCheckerTest.java" );
+		File file = new File( "projects/filetests/JavaFileCheckerTestFile.java" );
 		JavaFileChecker javaFileChecker = new JavaFileChecker(file);
 		List<SearchResult> searchResults = javaFileChecker.findMethodInvocations(null, "String", "valueOf", null);
 
@@ -29,7 +29,7 @@ public class JavaFileCheckerTest {
 
 	@Test
 	public void checkMethodInvocation() throws Exception {
-		File file = new File( "projects/filetests/JavaFileCheckerTest.java" );
+		File file = new File( "projects/filetests/JavaFileCheckerTestFile.java" );
 		JavaFileChecker javaFileChecker = new JavaFileChecker(file);
 		List<SearchResult> searchResults = javaFileChecker.findMethodInvocations("Foo", null, "bar", null);
 
@@ -47,7 +47,7 @@ public class JavaFileCheckerTest {
 	}
 	@Test
 	public void checkGuessMethodInvocation() {
-		File file = new File( "projects/filetests/JavaFileCheckerTest.java" );
+		File file = new File( "projects/filetests/JavaFileCheckerTestFile.java" );
 		JavaFileChecker javaFileChecker = new JavaFileChecker(file);
 		List<SearchResult> results = javaFileChecker.findMethodInvocations(null, "JavaFileChecker" , "staticCall", new String[]{"String","String","String"});
 		assertNotNull(results);

--- a/blade.migrate.liferay70/test/blade/migrate/core/JavaFileCheckerTest.java
+++ b/blade.migrate.liferay70/test/blade/migrate/core/JavaFileCheckerTest.java
@@ -51,9 +51,9 @@ public class JavaFileCheckerTest {
 		JavaFileChecker javaFileChecker = new JavaFileChecker(file);
 		List<SearchResult> results = javaFileChecker.findMethodInvocations(null, "JavaFileChecker" , "staticCall", new String[]{"String","String","String"});
 		assertNotNull(results);
-		assertEquals(3, results.size());
+		assertEquals(4, results.size());
 		results = javaFileChecker.findMethodInvocations("JavaFileChecker", null, "call", new String[]{"String","String","String"});
 		assertNotNull(results);
-		assertEquals(3, results.size());
+		assertEquals(4, results.size());
 	}
 }


### PR DESCRIPTION
Note:
if  we have two methods with same param number in one class which extends JavaFileMigrator as following code:
searchResults.addAll(javaFileChecker.findMethodInvocations(null, "LanguageUtil", "get",
				new String[] { "PortletConfig", "Locale", "String" }));
searchResults.addAll(javaFileChecker.findMethodInvocations(null, "LanguageUtil", "get",
				new String[] { "PortletConfig", "Locale", "Object" }));
And if there are codes like following in target file:
LanguageUtil.get(new PortletConfig(),new Locale(),foo.getString());
it will match twice because the last foo.getString() can't be resolved and the assert number will be more than expected