### PR TITLE
[migrator] put logic code of WebContentLegacyAPI into JavaFileChecker

### DIFF
--- a/blade.migrate.liferay70/src/blade/migrate/core/JavaFileChecker.java
+++ b/blade.migrate.liferay70/src/blade/migrate/core/JavaFileChecker.java
@@ -482,6 +482,29 @@ public class JavaFileChecker {
 		return searchResults;
 	}
 
+	public List<SearchResult> findMigratorService(final String[] prefixes, final String[] suffixes){
+		final List<SearchResult> searchResults = new ArrayList<>();
+
+		for (String prefix : prefixes) {
+			for (String suffix : suffixes) {
+				String serviceFQN = prefix + suffix;
+				SearchResult importResult = findImport(serviceFQN);
+
+				if (importResult != null) {
+					searchResults.add(importResult);
+				}
+
+				String serviceExpression = serviceFQN.substring(serviceFQN.lastIndexOf('.') + 1, serviceFQN.length());
+				searchResults.addAll(findMethodInvocations(null, serviceExpression, "*", null));
+
+				searchResults.addAll(findMethodInvocations(serviceExpression, null, "*", null));
+			}
+		}
+
+		return searchResults;
+	}
+
+
 	private static Map<File, WeakReference<CompilationUnit>> _map = new WeakHashMap<>();
 
 	private final CompilationUnit _ast;

--- a/blade.migrate.liferay70/src/blade/migrate/liferay70/WebContentLegacyAPI.java
+++ b/blade.migrate.liferay70/src/blade/migrate/liferay70/WebContentLegacyAPI.java
@@ -46,35 +46,7 @@ public class WebContentLegacyAPI extends JavaFileMigrator {
 
 	@Override
 	protected List<SearchResult> searchJavaFile(File file, JavaFileChecker javaFileChecker) {
-		final List<SearchResult> results = new ArrayList<>();
 
-		for (String prefix : PREFIXES) {
-			searchForServices(results, javaFileChecker, prefix);
-		}
-
-		return results;
-	}
-
-	private void searchForServices(List<SearchResult> results,
-			JavaFileChecker javaFileChecker, String serviceFQNPrefix) {
-
-		for (String suffix : SUFFIXES) {
-			searchForService(results, javaFileChecker, serviceFQNPrefix + suffix);
-		}
-	}
-
-	private void searchForService(List<SearchResult> results,
-			JavaFileChecker javaFileChecker, String serviceFQN) {
-
-		SearchResult importResult = javaFileChecker.findImport(serviceFQN);
-
-		if (importResult != null) {
-			results.add(importResult);
-		}
-
-		String serviceExpression = serviceFQN.substring(serviceFQN.lastIndexOf('.') + 1, serviceFQN.length());
-		results.addAll(javaFileChecker.findMethodInvocations(null, serviceExpression, "*", null));
-
-		results.addAll(javaFileChecker.findMethodInvocations(serviceFQN, null, "*", null));
+		return javaFileChecker.findMigratorService(PREFIXES, SUFFIXES);
 	}
 }

--- a/blade.migrate.liferay70/test/blade/migrate/liferay70/WebContentLegacyAPITest.java
+++ b/blade.migrate.liferay70/test/blade/migrate/liferay70/WebContentLegacyAPITest.java
@@ -30,7 +30,7 @@ public class WebContentLegacyAPITest {
 				new JavaFileChecker(testFile));
 
 		assertNotNull(results);
-		assertEquals(4, results.size());
+		assertEquals(5, results.size());
 
 		SearchResult problem = results.get(0);
 
@@ -40,17 +40,23 @@ public class WebContentLegacyAPITest {
 
 		problem = results.get(1);
 
+		assertEquals(47, problem.startLine);
+		assertEquals(1871, problem.startOffset);
+		assertEquals(1904, problem.endOffset);
+
+		problem = results.get(2);
+
 		assertEquals(21, problem.startLine);
 		assertEquals(1013, problem.startOffset);
 		assertEquals(1079, problem.endOffset);
 
-		problem = results.get(2);
+		problem = results.get(3);
 
 		assertEquals(41, problem.startLine);
 		assertEquals(1597, problem.startOffset);
 		assertEquals(1655, problem.endOffset);
 
-		problem = results.get(3);
+		problem = results.get(4);
 
 		assertEquals(45, problem.startLine);
 		assertEquals(1786, problem.startOffset);

--- a/blade.migrate.test/src/blade/migrate/test/AllProblemsTest.java
+++ b/blade.migrate.test/src/blade/migrate/test/AllProblemsTest.java
@@ -24,7 +24,7 @@ public class AllProblemsTest {
 				.findProblems(new File(
 						"../blade.migrate.liferay70/projects/"));
 
-		final int expectedSize = 178;
+		final int expectedSize = 179;
 		final int size = problems.size();
 
 		if (size != expectedSize) {


### PR DESCRIPTION
I think we can put these logic codes of WebContentLegacyAPI into JavaFileChecker so that we can't copy same logic code into our component. The code looks good.
What do you think ?